### PR TITLE
Fixed keys getting stuck when focus is lost

### DIFF
--- a/jquery.key.js
+++ b/jquery.key.js
@@ -6,13 +6,15 @@
  * Licensed under the MIT license (http://www.opensource.org/licenses/mit-license.php).
  * 2013/02/09
 */
-;(function ($, document) {
+;(function ($, document, window) {
     var keys = {a:65,b:66,c:67,d:68,e:69,f:70,g:71,h:72,i:73,j:74,k:75,l:76,m:77,n:78,o:79,p:80,q:81,r:82,s:83,t:84,u:85,v:86,w:87,x:88,y:89,z:90,"0":48,"1":49,"2":50,"3":51,"4":52,"5":53,"6":54,"7":55,"8":56,"9":57,f1:112,f2:113,f3:114,f4:115,f5:116,f6:117,f7:118,f8:119,f9:120,f10:121,f11:122,f12:123,shift:16,ctrl:17,control:17,alt:18,option:18,opt:18,cmd:224,command:224,fn:255,"function":255,backspace:8,osxdelete:8,enter:13,"return":13,space:32,spacebar:32,esc:27,escape:27,tab:9,capslock:20,capslk:20,"super":91,windows:91,insert:45,"delete":46,home:36,end:35,pgup:33,pageup:33,pgdn:34,pagedown:34,left:37,up:38,right:39,down:40,"!":49,"@":50,"#":51,"$":52,"%":53,"^":54,"&":55,"*":56,"(":57,")":48,"`":96,"~":96,"-":45,_:45,"=":187,"+":187,"[":219,"{":219,"]":221,"}":221,"\\":220,"|":220,";":59,":":59,"'":222,'"':222,",":188,"<":188,".":190,">":190,"/":191,"?":191};
     $.key = $.fn.key = function (code, fn) {
         if (!(this instanceof $)) { return $.fn.key.apply($(document), arguments); }
 
         var i = 0,
             cache = [];
+
+        $(window).on('focus', function (e) { cache = []; });
 
         return this.on({
             keydown: function (e) {
@@ -32,4 +34,4 @@
             }
         });
     };
-})(jQuery, document);
+})(jQuery, document, window);


### PR DESCRIPTION
Thanks for sharing this neat library. It works really well overall! However a small issue remains.

Pressed keys get "stuck" when the window doesn't have focus while they are released.

Steps to reproduce:
- Open http://yckart.github.io/jquery.key.js/ in a browser window which has other tabs
- Press Ctrl + Tab (focus changes to the next tab) and release both keys
- Change back to the jquery.key.js tab without pressing any keys (e.g. with the mouse)
- Press C
- Message with "ctrl+c" appears

This applies similarly to other focus changing keyboard shortcuts like Alt + Tab.

This PR fixes this problem by clearing the `cache` when the window gains or loses focus.
