### PR TITLE
Unbind old keydown/keyup events when the script call plugin multi-times

### DIFF
--- a/jquery.key.js
+++ b/jquery.key.js
@@ -14,8 +14,8 @@
         var i = 0,
             cache = [];
 
-        return this.on({
-            keydown: function (e) {
+        return this.off("keydown.Shortcut keyup.Shortcut").on({
+            "keydown.Shortcut": function (e) {
                 var key = e.which;
                 if (cache[cache.length - 1] === key) return;
                 cache.push(key);
@@ -26,7 +26,7 @@
                     i = 0;
                 }
             },
-            keyup: function () {
+            "keyup.Shortcut": function () {
                 i = 0;
                 cache = [];
             }


### PR DESCRIPTION
Unbind old keydown/keyup events when the script call plugin multi-times to prevent fire action multi times