### PR TITLE
Unbind old keydown/keyup events when the script calls plugin multi-times

### DIFF
--- a/jquery.key.js
+++ b/jquery.key.js
@@ -14,8 +14,8 @@
         var i = 0,
             cache = [];
 
-        return this.on({
-            keydown: function (e) {
+        return this.off("keydown.Shortcut keyup.Shortcut").on({
+            "keydown.Shortcut": function (e) {
                 var key = e.which;
                 if (cache[cache.length - 1] === key) return;
                 cache.push(key);
@@ -26,7 +26,7 @@
                     i = 0;
                 }
             },
-            keyup: function () {
+            "keyup.Shortcut": function () {
                 i = 0;
                 cache = [];
             }

--- a/jquery.key.js
+++ b/jquery.key.js
@@ -13,9 +13,11 @@
 
         var i = 0,
             cache = [];
+        var Keydown_Event = "keydown.Shortcut" + code.replace(/\+/,'_');
+        var Keyup_Event   = "keyup.Shortcut" + code.replace(/\+/,'_');
 
-        return this.off("keydown.Shortcut keyup.Shortcut").on({
-            "keydown.Shortcut": function (e) {
+
+        this.off(Keydown_Event).on(Keydown_Event, function (e) {
                 var key = e.which;
                 if (cache[cache.length - 1] === key) return;
                 cache.push(key);
@@ -25,11 +27,13 @@
                     fn(e, cache);
                     i = 0;
                 }
-            },
-            "keyup.Shortcut": function () {
-                i = 0;
+            });
+
+        this.off(Keyup_Event).on(Keyup_Event, function (e) {
+                i     = 0;
                 cache = [];
-            }
         });
+
+        return this;
     };
 })(jQuery, document);


### PR DESCRIPTION
Unbind old keydown/keyup events when the script calls plugin multi-times to prevent fire action multi times

